### PR TITLE
Removed admin middleware

### DIFF
--- a/emigate/conf/middlewares.yaml
+++ b/emigate/conf/middlewares.yaml
@@ -6,11 +6,6 @@ http:
         authResponseHeaders:
           - "X-Id-Token"
           - "Authorization"
-    admin:
-      basicAuth:
-        removeHeader: false
-        users:
-          - "admin:$2y$10$rKL6FOkiL9jxac9eZ9/ouutxnVRcWyB6A.R5lyoAm1QJgxelrLOMy"
     strip:
       stripPrefix:
         prefixes:

--- a/emigate/conf/routers.yaml
+++ b/emigate/conf/routers.yaml
@@ -14,7 +14,6 @@ http:
       service: api@internal
       middlewares:
         - auth
-        - admin
     emipass:
       entryPoints:
         - http


### PR DESCRIPTION
I guess it's okay for every authenticated user to access the dashboard for now. Later on, we should add an external authorization service responsible for judging if a particular user should be able to access a particular resource (gateway dashboard in this case). Closes #3.