### PR TITLE
Better dashboard routing

### DIFF
--- a/emigate/conf/routers.yaml
+++ b/emigate/conf/routers.yaml
@@ -10,7 +10,7 @@ http:
     admin:
       entryPoints:
         - admin
-      rule: PathPrefix(`/api`) || PathPrefix(`/dashboard`)
+      rule: PathPrefix(`/`)
       service: api@internal
       middlewares:
         - auth


### PR DESCRIPTION
Turns out #7 is a false positive. The dashboard is working, but you need to always add a trailing slash at the end. But now I added routing root to the dashboard so no one should be surprised anymore. Closes #7.